### PR TITLE
Config includes and timezone

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,11 +21,10 @@ url: "https://levelup.sh" # the base hostname & protocol for your site
 # Syntax reference: https://kramdown.gettalong.org/syntax.html
 markdown: kramdown
 
+include: [".well-known"]
+
 # Files to exclude from builds.
 exclude:
-  - .jekyll-cache/
-  - .gitignore
-  - .gitmodules
   - Gemfile
   - Gemfile.lock
   - Dockerfile

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ title: "LevelUp"
 version: "0x06"
 rego_url: "https://www.bugcrowd.com/resources/levelup0x06/registration/"
 con_datetime: "2020-05-09T:10:00-07:00"
+timezone: America/Los_Angeles # Used for site generation rubt TZ timestamping.
 con_timezone: "PDT"
 con_duration: "6" # in hours
 description: "LevelUp is Bugcrowd’s live information security conference, conducted entirely online via Youtube, Twitch, and Discord."

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ url: "https://levelup.sh" # the base hostname & protocol for your site
 # Syntax reference: https://kramdown.gettalong.org/syntax.html
 markdown: kramdown
 
-include: [".well-known"]
+include: [".well-known/matrix/client", ".well-known/matrix/client"]
 
 # Files to exclude from builds.
 exclude:

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ url: "https://levelup.sh" # the base hostname & protocol for your site
 # Syntax reference: https://kramdown.gettalong.org/syntax.html
 markdown: kramdown
 
-include: [".well-known/matrix/client", ".well-known/matrix/client"]
+include: [".well-known/matrix/client", ".well-known/matrix/server"]
 
 # Files to exclude from builds.
 exclude:


### PR DESCRIPTION
Trying to fix the `.well-known` files include — https://jekyllrb.com/docs/configuration/options/

Also adding a timezone for build timestamps to match PST/PDT.