### PR TITLE
fix: Stok Twitter handle

### DIFF
--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -10,7 +10,7 @@
 
 - handle: stok
   name: Fredrik Alexandersson
-  twitter: stok
+  twitter: stokfredrik
   hackergotchi: stok.jpg
 
 - handle: fuzzynop


### PR DESCRIPTION
STÖK's twitter handle is incorrect